### PR TITLE
Fix #12 - embed.FS broken on Windows

### DIFF
--- a/internal/util/osfs.go
+++ b/internal/util/osfs.go
@@ -11,21 +11,21 @@ type DirFS string
 var _ fs.FS = (*DirFS)(nil)
 
 func (dir DirFS) Open(name string) (fs.File, error) {
-	return os.Open(filepath.Join(string(dir), name))
+	return os.Open(filepath.Join(filepath.FromSlash(string(dir)), name))
 }
 
 func (dir DirFS) Stat(name string) (fs.FileInfo, error) {
-	return os.Stat(filepath.Join(string(dir), name))
+	return os.Stat(filepath.Join(filepath.FromSlash(string(dir)), name))
 }
 
 func (dir DirFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	return os.ReadDir(filepath.Join(string(dir), name))
+	return os.ReadDir(filepath.Join(filepath.FromSlash(string(dir)), name))
 }
 
 func (dir DirFS) ReadFile(name string) ([]byte, error) {
-	return os.ReadFile(filepath.Join(string(dir), name))
+	return os.ReadFile(filepath.Join(filepath.FromSlash(string(dir)), name))
 }
 
 func (dir DirFS) Glob(pattern string) ([]string, error) {
-	return filepath.Glob(filepath.Join(string(dir), pattern))
+	return filepath.Glob(filepath.Join(filepath.FromSlash(string(dir)), pattern))
 }

--- a/internal/util/osfs.go
+++ b/internal/util/osfs.go
@@ -11,21 +11,21 @@ type DirFS string
 var _ fs.FS = (*DirFS)(nil)
 
 func (dir DirFS) Open(name string) (fs.File, error) {
-	return os.Open(filepath.Join(filepath.FromSlash(string(dir)), name))
+	return os.Open(filepath.Join(string(dir), filepath.FromSlash(name)))
 }
 
 func (dir DirFS) Stat(name string) (fs.FileInfo, error) {
-	return os.Stat(filepath.Join(filepath.FromSlash(string(dir)), name))
+	return os.Stat(filepath.Join(string(dir), filepath.FromSlash(name)))
 }
 
 func (dir DirFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	return os.ReadDir(filepath.Join(filepath.FromSlash(string(dir)), name))
+	return os.ReadDir(filepath.Join(string(dir), filepath.FromSlash(name)))
 }
 
 func (dir DirFS) ReadFile(name string) ([]byte, error) {
-	return os.ReadFile(filepath.Join(filepath.FromSlash(string(dir)), name))
+	return os.ReadFile(filepath.Join(string(dir), filepath.FromSlash(name)))
 }
 
 func (dir DirFS) Glob(pattern string) ([]string, error) {
-	return filepath.Glob(filepath.Join(filepath.FromSlash(string(dir)), pattern))
+	return filepath.Glob(filepath.Join(string(dir), pattern))
 }

--- a/internal/util/osfs_test.go
+++ b/internal/util/osfs_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testdataDir = filepath.FromSlash("../../testdata/")
+
 func TestDirFS(t *testing.T) {
 	dir, err := os.MkdirTemp("", "spreakTest")
 	require.NoError(t, err)
@@ -49,4 +51,26 @@ func TestDirFS(t *testing.T) {
 	file2, err := fs.Open(filepath.Base(file.Name()))
 	assert.NoError(t, err)
 	assert.NoError(t, file2.Close())
+}
+
+func TestDirFS_CrossPlatform(t *testing.T) {
+	fsys := DirFS(testdataDir)
+
+	t.Run("stat", func(t *testing.T) {
+		info, err := fsys.Stat("structure/es/")
+		assert.NoError(t, err)
+		assert.True(t, info.IsDir())
+
+		info, err = fsys.Stat("structure/es/helloworld.po")
+		assert.NoError(t, err)
+		assert.Equal(t, "helloworld.po", info.Name())
+	})
+
+	t.Run("open", func(t *testing.T) {
+		f, err := fsys.Open("structure/es/helloworld.po")
+		if assert.NoError(t, err) {
+			defer f.Close()
+		}
+	})
+
 }

--- a/loader.go
+++ b/loader.go
@@ -1,14 +1,12 @@
 package spreak
 
 import (
-	"embed"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path"
-	"path/filepath"
 
 	"golang.org/x/text/language"
 
@@ -244,20 +242,9 @@ func (r *defaultResolver) Resolve(fsys fs.FS, extension string, tag language.Tag
 }
 
 func (r *defaultResolver) searchFileForLanguageName(fsys fs.FS, locale, domain, ext string) (string, error) {
-	// Function to assemble the path.
-	// Since for embedded file systems the separation of paths by slashes is used,
-	// a separate handling is necessary here.
-	// See: https://github.com/vorlif/spreak/issues/12
-	var joinFunc func(elem ...string) string
-	if _, isEmbedded := fsys.(embed.FS); isEmbedded {
-		joinFunc = path.Join
-	} else {
-		joinFunc = filepath.Join
-	}
-
 	if domain != "" {
 		// .../locale/category/domain.mo
-		searchPath := joinFunc(locale, r.category, domain+ext)
+		searchPath := path.Join(locale, r.category, domain+ext)
 		if _, err := fs.Stat(fsys, searchPath); err == nil {
 			return searchPath, nil
 		}
@@ -266,33 +253,33 @@ func (r *defaultResolver) searchFileForLanguageName(fsys fs.FS, locale, domain, 
 	if r.search {
 		if domain != "" {
 			// .../locale/LC_MESSAGES/domain.mo
-			searchPath := joinFunc(locale, "LC_MESSAGES", domain+ext)
+			searchPath := path.Join(locale, "LC_MESSAGES", domain+ext)
 			if _, err := fs.Stat(fsys, searchPath); err == nil {
 				return searchPath, nil
 			}
 
 			// .../locale/domain.mo
-			searchPath = joinFunc(locale, domain+ext)
+			searchPath = path.Join(locale, domain+ext)
 			if _, err := fs.Stat(fsys, searchPath); err == nil {
 				return searchPath, nil
 			}
 
 			// .../domain/locale.mo
-			searchPath = joinFunc(domain, locale+ext)
+			searchPath = path.Join(domain, locale+ext)
 			if _, err := fs.Stat(fsys, searchPath); err == nil {
 				return searchPath, nil
 			}
 		}
 
 		// .../locale.mo
-		searchPath := joinFunc(locale + ext)
+		searchPath := path.Join(locale + ext)
 		if _, err := fs.Stat(fsys, searchPath); err == nil {
 			return searchPath, nil
 		}
 
 		if r.category != "" {
 			// .../category/locale.mo
-			searchPath = joinFunc(r.category, locale+ext)
+			searchPath = path.Join(r.category, locale+ext)
 			if _, err := fs.Stat(fsys, searchPath); err == nil {
 				return searchPath, nil
 			}
@@ -300,7 +287,7 @@ func (r *defaultResolver) searchFileForLanguageName(fsys fs.FS, locale, domain, 
 
 		if r.category != "LC_MESSAGES" {
 			// .../LC_MESSAGES/locale.mo
-			searchPath = joinFunc("LC_MESSAGES", locale+ext)
+			searchPath = path.Join("LC_MESSAGES", locale+ext)
 			if _, err := fs.Stat(fsys, searchPath); err == nil {
 				return searchPath, nil
 			}

--- a/loader.go
+++ b/loader.go
@@ -148,6 +148,8 @@ func (l *FilesystemLoader) addDecoder(ext string, decoder catalog.Decoder) {
 }
 
 // WithFs stores a fs.FS as filesystem.
+// The file system can only be accessed with paths which are separated by slashes (Unix style).
+// If a different behavior is desired, a separate resolver must be stored with WithResolver.
 // Lets the creation of the FilesystemLoader fail, if a filesystem was already deposited.
 func WithFs(fsys fs.FS) FsOption {
 	return func(l *FilesystemLoader) error {

--- a/loader_test.go
+++ b/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -101,11 +102,11 @@ func TestLoadPo(t *testing.T) {
 	}{
 		{
 			language.German, "b", "my_category",
-			false, filepath.Join("de", "my_category", "b.po"), PoFile,
+			false, path.Join("de", "my_category", "b.po"), PoFile,
 		},
 		{
 			language.German, "a", "",
-			false, filepath.Join("de", "LC_MESSAGES", "a.po"), PoFile,
+			false, path.Join("de", "LC_MESSAGES", "a.po"), PoFile,
 		},
 		{
 			language.French, "a", "",
@@ -125,14 +126,14 @@ func TestLoadPo(t *testing.T) {
 		reducer, errR := NewDefaultResolver(WithCategory(tt.category))
 		require.NoError(t, errR)
 		require.NotNil(t, reducer)
-		path, err := reducer.Resolve(fsys, tt.extension, tt.lang, tt.domain)
+		resolvedPath, err := reducer.Resolve(fsys, tt.extension, tt.lang, tt.domain)
 		if tt.wantErr {
 			assert.Error(t, err)
 			continue
 		}
 
 		if assert.NoError(t, err, "Resolve(... %v %v %v %v...", tt.lang, tt.domain, tt.category, tt.extension) {
-			assert.Equal(t, tt.wantPath, path)
+			assert.Equal(t, tt.wantPath, resolvedPath)
 		}
 	}
 
@@ -168,14 +169,14 @@ func TestReduceMoFiles(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		path, err := reducer.Resolve(fsys, tt.extension, tt.lang, tt.domain)
+		resolvedPath, err := reducer.Resolve(fsys, tt.extension, tt.lang, tt.domain)
 		if tt.wantErr {
 			assert.Error(t, err)
 			continue
 		}
 
 		if assert.NoError(t, err) {
-			assert.Equal(t, tt.wantPath, path)
+			assert.Equal(t, tt.wantPath, resolvedPath)
 		}
 	}
 }
@@ -213,14 +214,14 @@ func TestDisableSearch(t *testing.T) {
 		require.NoError(t, errR)
 		require.NotNil(t, reducer)
 
-		path, err := reducer.Resolve(fsys, tt.extension, tt.lang, tt.domain)
+		resolvedPath, err := reducer.Resolve(fsys, tt.extension, tt.lang, tt.domain)
 		if tt.wantErr {
 			assert.Error(t, err, idx)
 			continue
 		}
 
 		if assert.NoError(t, err, idx) {
-			assert.Equal(t, tt.wantPath, path)
+			assert.Equal(t, tt.wantPath, resolvedPath)
 		}
 	}
 }

--- a/loader_test.go
+++ b/loader_test.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"testing"
 	"testing/fstest"
@@ -197,11 +196,11 @@ func TestDisableSearch(t *testing.T) {
 		},
 		{
 			language.German, "a", "LC_MESSAGES",
-			false, filepath.Join("de", "LC_MESSAGES", "a.po"), PoFile,
+			false, path.Join("de", "LC_MESSAGES", "a.po"), PoFile,
 		},
 		{
 			language.German, "b", "my_category",
-			false, filepath.Join("de", "my_category", "b.po"), PoFile,
+			false, path.Join("de", "my_category", "b.po"), PoFile,
 		},
 		{
 			language.English, "domain", "cat",

--- a/testdata/structure/es/helloworld.po
+++ b/testdata/structure/es/helloworld.po
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE VERSION package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-05-06 14:53+0200\n"
+"PO-Revision-Date: 2022-05-06 14:57+0200\n"
+"Last-Translator: Florian Vogt\n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#. TRANSLATORS: This comment is automatically extracted by xspreak
+#. and can be used to leave useful hints for the translators.
+#: ../helloworld/main.go:26
+msgid "Hello world"
+msgstr "Hola Mundo"


### PR DESCRIPTION
#### Summary

Fix #12. See Issue for a detailed description of the problem.

We now use, `path.Join` to assemble paths. The spreak `fs.FS` implementation for the file system access converts the paths, before the file system access, into a path suitable for the operating system.  I see this change exclusively as a bug fix and not as a breaking change, since according to the [FS documentation](https://pkg.go.dev/io/fs#ValidPath), an fs path must always be separated by slashes. 