### PR TITLE
Run CI tests against Go v1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,10 @@ jobs:
         - macOS
         - windows
         go:
-        - 16
         - 17
         - 18
         - 19
+        - 20
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:


### PR DESCRIPTION
#### Summary

* CI tests will run against Go v1.20
* Go v1.16 removed from CI tests