### PR TITLE
Add go v1.21 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,9 @@ jobs:
         - macOS
         - windows
         go:
-        - 17
-        - 18
         - 19
         - 20
+        - 21
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ run:
   timeout: 5m
 
   skip-dirs-use-default: true
+  skip-dirs:
+    - humanize/locale
 
 linters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ gofmt:
 
 
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
-
 	@echo Running golangci-lint
 	golangci-lint run --fix ./...
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spreak ![Test status](https://github.com/vorlif/spreak/workflows/Test/badge.svg) [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![PkgGoDev](https://pkg.go.dev/badge/github.com/vorlif/spreak)](https://pkg.go.dev/github.com/vorlif/spreak) [![Go Report Card](https://goreportcard.com/badge/github.com/vorlif/spreak)](https://goreportcard.com/report/github.com/vorlif/spreak) [![codecov](https://codecov.io/gh/vorlif/spreak/branch/main/graph/badge.svg?token=N1O0ZE1OFW)](https://codecov.io/gh/vorlif/spreak) ![MinVersion](https://img.shields.io/badge/Go-1.17+-blue)
 
-Flexible translation and humanization library for Go, based on the concepts behind gettext. Requires Go 1.17+.
+Flexible translation and humanization library for Go, based on the concepts behind gettext. Requires Go 1.19+.
 
 ### Why another library?
 

--- a/catalog/cldrplural/ast/scanner.go
+++ b/catalog/cldrplural/ast/scanner.go
@@ -56,8 +56,8 @@ func newScanner(content string) *scanner {
 }
 
 func (s *scanner) Scan() (tok Token, lit string) {
-	lit, err := s.read()
-	if err != nil {
+	lit, errR := s.read()
+	if errR != nil {
 		return eof, ""
 	}
 
@@ -101,9 +101,9 @@ func (s *scanner) Scan() (tok Token, lit string) {
 		return ValueRange, lit
 	} else if reSampleRange.MatchString(lit) {
 		return sampleRange, lit
-	} else {
-		return unknown, lit
 	}
+
+	return unknown, lit
 }
 
 func (s *scanner) read() (string, error) {

--- a/catalog/po/encoder.go
+++ b/catalog/po/encoder.go
@@ -18,7 +18,6 @@ type Encoder struct {
 	writeHeader      bool
 	writeEmptyHeader bool
 	writeReferences  bool
-	sort             bool
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -32,25 +31,33 @@ func NewEncoder(w io.Writer) *Encoder {
 	}
 }
 
+// SetWrapWidth defines at which length the texts should be wrapped.
+// To disable wrapping, the value can be set to -1.
+// Default is -1.
 func (e *Encoder) SetWrapWidth(wrapWidth int) {
 	e.wrapWidth = wrapWidth
 }
 
+// SetWriteHeader sets whether a header should be written or not.
+// Default is true.
 func (e *Encoder) SetWriteHeader(write bool) {
 	e.writeHeader = write
 }
 
-func (e *Encoder) SetWriteReferences(write bool) {
-	e.writeReferences = write
-}
-
+// SetWriteEmptyHeader sets whether a header without values should also be written or not.
+// Default is true.
 func (e *Encoder) SetWriteEmptyHeader(write bool) {
 	e.writeEmptyHeader = write
 }
 
-func (e *Encoder) SetSort(sort bool) {
-	e.sort = sort
+// SetWriteReferences sets whether references to the origin of the text should be stored or not.
+// Default is true.
+func (e *Encoder) SetWriteReferences(write bool) {
+	e.writeReferences = write
 }
+
+// Deprecated: Obsolete, it is always sorted, the method is removed with version 1.0.
+func (e *Encoder) SetSort(_ bool) {}
 
 func (e *Encoder) Encode(f *File) error {
 	if f.Header != nil && e.writeHeader {

--- a/catalog/po/message.go
+++ b/catalog/po/message.go
@@ -38,7 +38,7 @@ func (m *Message) Less(q *Message) bool {
 	}
 
 	if a, b := m.ID, q.ID; a != b {
-		return a < b
+		return a > b
 	}
 
 	return false

--- a/catalog/po/message_test.go
+++ b/catalog/po/message_test.go
@@ -49,9 +49,9 @@ func TestMessage_Less(t *testing.T) {
 		m.ID = "a"
 		o.ID = "b"
 
-		assert.True(t, m.Less(o))
-		m.ID = "c"
 		assert.False(t, m.Less(o))
+		m.ID = "c"
+		assert.True(t, m.Less(o))
 	})
 
 	t.Run("Otherwise false is returned", func(t *testing.T) {

--- a/catalog/po/scanner.go
+++ b/catalog/po/scanner.go
@@ -139,14 +139,15 @@ func (s *scanner) scanWhitespace() (tok token, lit string) {
 	buf.WriteString(currentLine)
 
 	for {
-		if line, err := s.read(); err == io.EOF {
+		line, err := s.read()
+		if err == io.EOF {
 			break
 		} else if !reBlankLine.MatchString(line) {
 			s.unread()
 			break
-		} else {
-			buf.WriteString(line)
 		}
+
+		buf.WriteString(line)
 	}
 
 	return whitespace, buf.String()

--- a/catalog/poplural/ast/parser.go
+++ b/catalog/poplural/ast/parser.go
@@ -278,18 +278,19 @@ func (p *parser) multiplicativeExpression() (Node, error) {
 }
 
 func (p *parser) pmExpression() (Node, error) {
-	if p.lastToken == Operand {
+	switch p.lastToken {
+	case Operand:
 		if errScan := p.scanNext(); errScan != nil {
 			return nil, errScan
 		}
 		return &OperandExpr{}, nil
-	} else if p.lastToken == Value {
+	case Value:
 		value, _ := strconv.ParseInt(p.lastLiteral, 10, 64)
 		if errScan := p.scanNext(); errScan != nil {
 			return nil, errScan
 		}
 		return &ValueExpr{Value: value}, nil
-	} else if p.lastToken == leftBracket {
+	case leftBracket:
 		if errScan := p.scanNext(); errScan != nil {
 			return nil, errScan
 		}
@@ -308,7 +309,7 @@ func (p *parser) pmExpression() (Node, error) {
 		}
 
 		return exprNode, nil
-	} else {
+	default:
 		return nil, fmt.Errorf("found %q, expected something other", p.lastLiteral)
 	}
 }

--- a/catalog/poplural/ast/scanner.go
+++ b/catalog/poplural/ast/scanner.go
@@ -90,14 +90,15 @@ func (s *scanner) scanWhitespace() (tok Token, lit string) {
 	buf.WriteRune(s.read())
 
 	for {
-		if ch := s.read(); ch == scannerEOF {
+		ch := s.read()
+		if ch == scannerEOF {
 			break
 		} else if !isWhitespace(ch) {
 			s.unread()
 			break
-		} else {
-			buf.WriteRune(ch)
 		}
+
+		buf.WriteRune(ch)
 	}
 
 	return whitespace, buf.String()
@@ -109,14 +110,14 @@ func (s *scanner) scanNumber() (tok Token, lit string) {
 	buf.WriteRune(s.read())
 
 	for {
-		if ch := s.read(); ch == scannerEOF {
+		ch := s.read()
+		if ch == scannerEOF {
 			break
 		} else if !isDigit(ch) && ch != '_' {
 			s.unread()
 			break
-		} else {
-			_, _ = buf.WriteRune(ch)
 		}
+		_, _ = buf.WriteRune(ch)
 	}
 
 	return Value, buf.String()
@@ -127,14 +128,14 @@ func (s *scanner) scanText() (tok Token, lit string) {
 	buf.WriteRune(s.read())
 
 	for {
-		if ch := s.read(); ch == scannerEOF {
+		ch := s.read()
+		if ch == scannerEOF {
 			break
 		} else if !isLetter(ch) && ch != '_' {
 			s.unread()
 			break
-		} else {
-			_, _ = buf.WriteRune(ch)
 		}
+		_, _ = buf.WriteRune(ch)
 	}
 
 	switch strings.ToLower(buf.String()) {

--- a/catalog/poplural/evaluation.go
+++ b/catalog/poplural/evaluation.go
@@ -52,15 +52,13 @@ func Parse(rule string) (*Form, error) {
 }
 
 func generateFormFunc(forms *ast.Forms) func(n int64) int {
-	return func(n int64) int { return evaluate(forms, n) }
-}
-
-func evaluate(forms *ast.Forms, num int64) int {
 	if forms.Root == nil {
-		return 0
+		return func(n int64) int { return 0 }
 	}
 
-	return int(evaluateNode(forms.Root, num))
+	return func(n int64) int {
+		return int(evaluateNode(forms.Root, n))
+	}
 }
 
 func evaluateNode(node ast.Node, num int64) int64 {

--- a/catalog/poplural/evaluation_test.go
+++ b/catalog/poplural/evaluation_test.go
@@ -84,10 +84,10 @@ func TestEvaluate(t *testing.T) {
 		assert.NotNil(t, f)
 
 		f.Root = nil
-		assert.Zero(t, evaluate(f, -1))
-		assert.Zero(t, evaluate(f, 0))
-		assert.Zero(t, evaluate(f, 1))
-		assert.Zero(t, evaluate(f, 10))
+		assert.Zero(t, generateFormFunc(f)(-1))
+		assert.Zero(t, generateFormFunc(f)(0))
+		assert.Zero(t, generateFormFunc(f)(1))
+		assert.Zero(t, generateFormFunc(f)(10))
 	})
 
 	t.Run("test invalid input", func(t *testing.T) {

--- a/humanize/date.go
+++ b/humanize/date.go
@@ -132,6 +132,7 @@ func (h *Humanizer) NaturalTime(i interface{}) string {
 	if t.Before(now) {
 		delta := now.Sub(t)
 		deltaSec := int64(delta.Truncate(time.Second).Seconds())
+
 		if int64(delta.Round(time.Second).Hours()) >= 24 {
 			entry := naturalTimeStrings["past-day"]
 			timeSince := h.TimeSince(t, withTimeStrings(naturalPastSubstrings))
@@ -146,11 +147,11 @@ func (h *Humanizer) NaturalTime(i interface{}) string {
 			count := int64(math.Floor(float64(deltaSec) / 60))
 			entry := naturalTimeStrings["past-minute"]
 			return h.loc.NGetf(entry.singular, entry.plural, count, count)
-		} else {
-			count := int64(math.Floor(math.Floor(float64(deltaSec)/60) / 60))
-			entry := naturalTimeStrings["past-hour"]
-			return h.loc.NGetf(entry.singular, entry.plural, count, count)
 		}
+
+		count := int64(math.Floor(math.Floor(float64(deltaSec)/60) / 60))
+		entry := naturalTimeStrings["past-hour"]
+		return h.loc.NGetf(entry.singular, entry.plural, count, count)
 	}
 
 	delta := t.Sub(now)
@@ -169,11 +170,11 @@ func (h *Humanizer) NaturalTime(i interface{}) string {
 		count := int64(math.Floor(float64(deltaSec) / 60))
 		entry := naturalTimeStrings["future-minute"]
 		return h.loc.NGetf(entry.singular, entry.plural, count, count)
-	} else {
-		count := int64(math.Floor(math.Floor(float64(deltaSec)/60) / 60))
-		entry := naturalTimeStrings["future-hour"]
-		return h.loc.NGetf(entry.singular, entry.plural, count, count)
 	}
+
+	count := int64(math.Floor(math.Floor(float64(deltaSec)/60) / 60))
+	entry := naturalTimeStrings["future-hour"]
+	return h.loc.NGetf(entry.singular, entry.plural, count, count)
 }
 
 var timeSinceStrings = map[string]gettextEntry{
@@ -344,9 +345,9 @@ func (h *Humanizer) TimeSince(inputTime interface{}, opts ...TimeOption) string 
 		if count <= 0 {
 			if o.requireAdjacent {
 				break
-			} else {
-				continue
 			}
+
+			continue
 		}
 		entry := o.timeStrings[chunk.name]
 		result = append(result, h.loc.NPGetf(entry.context, entry.singular, entry.plural, count, count))

--- a/loader.go
+++ b/loader.go
@@ -23,10 +23,12 @@ const (
 
 // Catalog represents a collection of messages (translations) for a language and a domain.
 // Normally it is a PO or MO file.
+//
 // Deprecated: Moved to catalog.Catalog. This alias will be removed in version 1.0.
 type Catalog = catalog.Catalog
 
 // A Decoder reads and decodes catalogs for a language and a domain from a byte array.
+//
 // Deprecated: Moved to catalog.Decoder and will be removed with v1.0.
 type Decoder = catalog.Decoder
 


### PR DESCRIPTION
#### Summary

* Remove support for Golang v1.17 and v1.18
* Add Golang v1.21 to the tests
* Lint customizations