### PR TITLE
Fix: Multiline translations in Po files are not written correctly

### DIFF
--- a/catalog/po/encoder.go
+++ b/catalog/po/encoder.go
@@ -242,18 +242,18 @@ func (e *Encoder) encodeMessage(m *Message) error {
 func (e *Encoder) encodeTranslations(plural bool, orig map[int]string) error {
 	m := make(map[int]string, len(orig))
 	for k, v := range orig {
-		m[k] = v
+		m[k] = EncodePoString(v, e.wrapWidth)
 	}
 
 	// We need at least one entry
 	if len(m) == 0 {
-		m[0] = ""
+		m[0] = `""`
 	}
 
 	if plural {
 		if len(m) == 1 {
 			// Plural needs at least two entries
-			m[1] = ""
+			m[1] = `""`
 		}
 
 		keys := make([]int, 0, len(m))
@@ -263,12 +263,12 @@ func (e *Encoder) encodeTranslations(plural bool, orig map[int]string) error {
 		sort.Ints(keys)
 
 		for _, k := range keys {
-			if _, err := e.w.WriteString(fmt.Sprintf("msgstr[%d] \"%s\"\n", k, m[k])); err != nil {
+			if _, err := e.w.WriteString(fmt.Sprintf("msgstr[%d] %s\n", k, m[k])); err != nil {
 				return err
 			}
 		}
 	} else {
-		if _, err := e.w.WriteString(fmt.Sprintf("msgstr \"%s\"\n", m[0])); err != nil {
+		if _, err := e.w.WriteString(fmt.Sprintf("msgstr %s\n", m[0])); err != nil {
 			return err
 		}
 	}

--- a/catalog/po/encoder_test.go
+++ b/catalog/po/encoder_test.go
@@ -155,6 +155,27 @@ msgstr[2] "c"
 		require.NoError(t, err)
 		assert.Equal(t, want, buff.String())
 	})
+
+	t.Run("Multiline are written correctly", func(t *testing.T) {
+		f := NewFile()
+		f.Header = nil
+
+		msg = NewMessage()
+		msg.ID = "Australian English"
+		msg.Str[0] = `ئاۋىستىرالىيە ئىنگلزچىسى
+ `
+		f.AddMessage(msg)
+		buff.Reset()
+		err := enc.Encode(f)
+		require.NoError(t, err)
+		want := `msgid "Australian English"
+msgstr ""
+"ئاۋىستىرالىيە ئىنگلزچىسى\n"
+" "
+
+`
+		assert.Equal(t, want, buff.String())
+	})
 }
 
 func TestEncoderDisableWriteReference(t *testing.T) {

--- a/catalog/po/parser_test.go
+++ b/catalog/po/parser_test.go
@@ -79,6 +79,27 @@ msgstr ""`
 		assert.Error(t, err)
 		assert.Nil(t, f)
 	})
+
+	t.Run("multiline with special character", func(t *testing.T) {
+		content := `
+msgid "Australian English"
+msgstr ""
+"ئاۋىستىرالىيە ئىنگلزچىسى\n"
+" "
+`
+		f, err := Parse([]byte(content))
+		require.NoError(t, err)
+		assert.NotNil(t, f)
+
+		msg := f.GetMessage("", "Australian English")
+		require.NotNil(t, msg)
+		require.Contains(t, msg.Str, 0)
+
+		want := `ئاۋىستىرالىيە ئىنگلزچىسى
+ `
+
+		assert.Equal(t, want, msg.Str[0])
+	})
 }
 
 func TestParse_Header(t *testing.T) {

--- a/catalog/po/util_test.go
+++ b/catalog/po/util_test.go
@@ -61,6 +61,21 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr,      sed diam nonumy ei
 			})
 		}
 	})
+
+	t.Run("unicode characters", func(t *testing.T) {
+		input := `ئاۋىستىرالىيە ئىنگلزچىسى
+ `
+		get := EncodePoString(input, -1)
+		want := `""
+"ئاۋىستىرالىيە ئىنگلزچىسى\n"
+" "`
+		assert.Equal(t, want, get)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		get := EncodePoString("", -1)
+		assert.Equal(t, `""`, get)
+	})
 }
 
 func TestDecodePoString(t *testing.T) {


### PR DESCRIPTION
#### Summary

If a translation in a Po file went over several lines, it was not encoded correctly. This had no effect on the translation function, only on the export of Po files. 