### PR TITLE
Fix: Translations marked as fuzzy were used

### DIFF
--- a/catalog/po.go
+++ b/catalog/po.go
@@ -93,6 +93,10 @@ func buildGettextCatalog(file *po.File, lang language.Tag, domain string, useCLD
 				continue
 			}
 
+			if poMsg.Comment != nil && poMsg.Comment.HasFlag("fuzzy") {
+				continue
+			}
+
 			d := &gettextMessage{
 				Context:      poMsg.Context,
 				ID:           poMsg.ID,

--- a/catalog/po_test.go
+++ b/catalog/po_test.go
@@ -93,6 +93,10 @@ msgstr[1] "%d Tage"
 
 msgid "Special\t	\"chars\""
 msgstr "Sonder\t	\"zeichen\""
+
+#, fuzzy
+msgid "Unknown"
+msgstr "Fuzzy translation"
 `
 
 func TestPoDecoder(t *testing.T) {
@@ -116,6 +120,10 @@ func TestPoDecoder(t *testing.T) {
 	translation, err = catl.GetTranslation("", "xyz")
 	assert.Error(t, err)
 	assert.Equal(t, "xyz", translation)
+
+	translation, err = catl.GetTranslation("", "Unknown")
+	assert.Error(t, err)
+	assert.Equal(t, "Unknown", translation)
 
 	catl, err = dec.Decode(lang, domain, []byte(decodePoInvalidPluralForm+decodeTestData))
 	assert.Error(t, err)


### PR DESCRIPTION
#### Summary

Translations that were marked as fuzzy in Po files were still used for the translation. 