### PR TITLE
Fix: Gettext flags are not parsed correctly

### DIFF
--- a/catalog/po/encoder_test.go
+++ b/catalog/po/encoder_test.go
@@ -176,6 +176,26 @@ msgstr ""
 `
 		assert.Equal(t, want, buff.String())
 	})
+
+	t.Run("flags encoded correctly", func(t *testing.T) {
+		f := NewFile()
+		f.Header = nil
+
+		msg = NewMessage()
+		msg.ID = "Hello"
+		msg.Comment = NewComment()
+		msg.Comment.Flags = append(msg.Comment.Flags, "fuzzy", "go-format")
+		f.AddMessage(msg)
+		buff.Reset()
+		err := enc.Encode(f)
+		require.NoError(t, err)
+		want := `#, fuzzy, go-format
+msgid "Hello"
+msgstr ""
+
+`
+		assert.Equal(t, want, buff.String())
+	})
 }
 
 func TestEncoderDisableWriteReference(t *testing.T) {

--- a/catalog/po/parser.go
+++ b/catalog/po/parser.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 type parser struct {
@@ -190,7 +191,9 @@ func (p *parser) parseComment() (*Comment, error) {
 			comment.Extracted += line
 		case commentFlags:
 			line = strings.TrimSpace(line[2:]) // #,
-			rawFlags := strings.Split(line, " ")
+			rawFlags := strings.FieldsFunc(line, func(r rune) bool {
+				return unicode.IsSpace(r) || r == ','
+			})
 			for _, flag := range rawFlags {
 				comment.Flags = append(comment.Flags, strings.TrimSpace(flag))
 			}

--- a/catalog/po/parser.go
+++ b/catalog/po/parser.go
@@ -191,12 +191,8 @@ func (p *parser) parseComment() (*Comment, error) {
 			comment.Extracted += line
 		case commentFlags:
 			line = strings.TrimSpace(line[2:]) // #,
-			rawFlags := strings.FieldsFunc(line, func(r rune) bool {
-				return unicode.IsSpace(r) || r == ','
-			})
-			for _, flag := range rawFlags {
-				comment.Flags = append(comment.Flags, strings.TrimSpace(flag))
-			}
+			rawFlags := strings.FieldsFunc(line, func(r rune) bool { return unicode.IsSpace(r) || r == ',' })
+			comment.Flags = append(comment.Flags, rawFlags...)
 		case commentPrevContext:
 			line = strings.TrimSpace(line[10:]) // #| msgctxt
 			if line == "" {

--- a/catalog/po/parser_test.go
+++ b/catalog/po/parser_test.go
@@ -257,6 +257,23 @@ msgstr[1] "%(value)s Billionen"
 		assert.Equal(t, msg.Comment.Flags[0], "python-format")
 	})
 
+	t.Run("parse multiple flags", func(t *testing.T) {
+		content := `#,  python-format, fuzzy  test
+msgid "%(value)s trillion"
+msgstr ""
+`
+		file, err := Parse([]byte(content))
+		require.NoError(t, err)
+		require.NotNil(t, file)
+		require.NotNil(t, file.Messages)
+
+		msg := file.GetMessage("", "%(value)s trillion")
+		assert.True(t, msg.Comment.HasFlag("python-format"))
+		assert.True(t, msg.Comment.HasFlag("fuzzy"))
+		assert.True(t, msg.Comment.HasFlag("test"))
+		assert.False(t, msg.Comment.HasFlag("unknown"))
+	})
+
 	t.Run("test parse message prev", func(t *testing.T) {
 		content := `
 #| msgctxt "prev "

--- a/catalog/po/parser_test.go
+++ b/catalog/po/parser_test.go
@@ -258,7 +258,7 @@ msgstr[1] "%(value)s Billionen"
 	})
 
 	t.Run("parse multiple flags", func(t *testing.T) {
-		content := `#,  python-format, fuzzy  test
+		content := `#,  python-format, fuzzy  test  
 msgid "%(value)s trillion"
 msgstr ""
 `


### PR DESCRIPTION
#### Summary

The flags in Po files were not parsed correctly if there were several flags and these were separated by a comma. 