### PR TITLE
Po encoding rewritten

### DIFF
--- a/catalog/po/comment.go
+++ b/catalog/po/comment.go
@@ -48,6 +48,7 @@ func (c *Comment) AddReference(ref *Reference) {
 	c.sort()
 }
 
+// Deprecated: Will be removed in a future release.
 func (c *Comment) Less(q *Comment) bool {
 	c.sort()
 	for i := 0; i < len(c.References); i++ {

--- a/catalog/po/encoder.go
+++ b/catalog/po/encoder.go
@@ -1,73 +1,109 @@
 package po
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/vorlif/spreak/internal/util"
 )
 
+// Marshal serializes a Go File as a .po document.
+//
+// It is a shortcut for Encoder.Encode() with the default options.
+func Marshal(f *File) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf)
+
+	err := enc.Encode(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
 // An Encoder writes a po file to an output stream.
 type Encoder struct {
-	w                *bufio.Writer
+	w                io.Writer
 	wrapWidth        int
 	writeHeader      bool
 	writeEmptyHeader bool
 	writeReferences  bool
+	// Is a less than or equal to function which can be used to sort the messages of a Po file.
+	sortFunction func(a *Message, b *Message) bool
 }
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
-		w:                bufio.NewWriter(w),
+		w:                w,
 		wrapWidth:        -1,
 		writeHeader:      true,
 		writeReferences:  true,
 		writeEmptyHeader: true,
+		sortFunction:     DefaultSortFunction,
 	}
 }
 
 // SetWrapWidth defines at which length the texts should be wrapped.
 // To disable wrapping, the value can be set to -1.
 // Default is -1.
-func (e *Encoder) SetWrapWidth(wrapWidth int) {
-	e.wrapWidth = wrapWidth
+func (enc *Encoder) SetWrapWidth(wrapWidth int) {
+	enc.wrapWidth = wrapWidth
 }
 
 // SetWriteHeader sets whether a header should be written or not.
 // Default is true.
-func (e *Encoder) SetWriteHeader(write bool) {
-	e.writeHeader = write
+func (enc *Encoder) SetWriteHeader(write bool) {
+	enc.writeHeader = write
 }
 
 // SetWriteEmptyHeader sets whether a header without values should also be written or not.
 // Default is true.
-func (e *Encoder) SetWriteEmptyHeader(write bool) {
-	e.writeEmptyHeader = write
+func (enc *Encoder) SetWriteEmptyHeader(write bool) {
+	enc.writeEmptyHeader = write
 }
 
 // SetWriteReferences sets whether references to the origin of the text should be stored or not.
 // Default is true.
-func (e *Encoder) SetWriteReferences(write bool) {
-	e.writeReferences = write
+func (enc *Encoder) SetWriteReferences(write bool) {
+	enc.writeReferences = write
+}
+
+// SetSortFunction can be used to set a smaller than function with which the messages can be sorted before writing.
+func (enc *Encoder) SetSortFunction(f func(a *Message, b *Message) bool) {
+	enc.sortFunction = f
 }
 
 // Deprecated: Obsolete, it is always sorted, the method is removed with version 1.0.
-func (e *Encoder) SetSort(_ bool) {}
+// Alternatively, a custom sort function can be set with SetSortFunction.
+func (enc *Encoder) SetSort(_ bool) {}
 
-func (e *Encoder) Encode(f *File) error {
-	if f.Header != nil && e.writeHeader {
-		if err := e.encodeHeader(f.Header); err != nil {
-			return err
-		}
+func (enc *Encoder) Encode(f *File) error {
+	if f == nil {
+		return fmt.Errorf("po: cannot encode a nil interface")
+	}
 
-		if _, err := e.w.WriteString("\n"); err != nil {
-			return err
-		}
+	b := enc.encode(f)
+	_, err := enc.w.Write(b)
+	if err != nil {
+		return fmt.Errorf("po: cannot write: %w", err)
+	}
+
+	return nil
+}
+
+func (enc *Encoder) encode(f *File) []byte {
+	// We initialize the buffer with 50Kb, which should be sufficient for medium-sized projects.
+	buff := bytes.NewBuffer(make([]byte, 0, 50*1024))
+
+	if f.Header != nil && enc.writeHeader {
+		enc.encodeHeader(buff, f.Header)
+		buff.WriteString("\n")
 	}
 
 	if f.Messages != nil {
@@ -78,20 +114,17 @@ func (e *Encoder) Encode(f *File) error {
 			}
 		}
 		sort.Slice(messages, func(i, j int) bool {
-			return messages[j].Less(messages[i])
+			return enc.sortFunction(messages[j], messages[i])
 		})
-		for _, msg := range messages {
-			if err := e.encodeMessage(msg); err != nil {
-				return err
+		for i, msg := range messages {
+			if i > 0 {
+				buff.WriteString("\n")
 			}
-
-			if _, err := e.w.WriteString("\n"); err != nil {
-				return err
-			}
+			enc.encodeMessage(buff, msg)
 		}
 	}
 
-	return e.w.Flush()
+	return buff.Bytes()
 }
 
 type headerEntry struct {
@@ -99,10 +132,8 @@ type headerEntry struct {
 	value string
 }
 
-func (e *Encoder) encodeHeader(h *Header) error {
-	if err := e.encodeComment(h.Comment); err != nil {
-		return err
-	}
+func (enc *Encoder) encodeHeader(buff *bytes.Buffer, h *Header) {
+	enc.encodeComment(buff, h.Comment)
 
 	headers := []headerEntry{
 		{HeaderProjectIDVersion, h.ProjectIDVersion},
@@ -123,7 +154,7 @@ func (e *Encoder) encodeHeader(h *Header) error {
 		headers = append(headers, headerEntry{k, v})
 	}
 
-	if !e.writeEmptyHeader {
+	if !enc.writeEmptyHeader {
 		var hasHeader bool
 		for _, header := range headers {
 			if header.value != "" {
@@ -132,117 +163,104 @@ func (e *Encoder) encodeHeader(h *Header) error {
 			}
 		}
 		if !hasHeader {
-			return nil
+			return
 		}
 	}
 
-	lines := make([]string, 0, len(headers))
-	lines = append(lines, `msgid ""`+"\n")
-	lines = append(lines, `msgstr ""`+"\n")
+	buff.WriteString(`msgid ""
+msgstr ""
+`)
+
 	for _, header := range headers {
 		isOptional := header.key == HeaderMIMEVersion || header.key == HeaderPluralForms || header.key == HeaderXGenerator
 		if isOptional && header.value == "" {
 			continue
 		}
-		lines = append(lines, fmt.Sprintf(`"%s: %s\n"`+"\n", header.key, header.value))
+		buff.WriteRune('"')
+		buff.WriteString(header.key)
+		buff.WriteString(": ")
+		buff.WriteString(header.value)
+		buff.WriteString("\\n\"\n")
 	}
-
-	for _, line := range lines {
-		if _, err := e.w.WriteString(line); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
-func (e *Encoder) encodeComment(c *Comment) error {
+func (enc *Encoder) encodeComment(buff *bytes.Buffer, c *Comment) {
 	if c == nil {
-		return nil
+		return
 	}
 
 	if c.Translator != "" {
-		for _, comment := range util.WrapString(c.Translator, e.wrapWidth) {
-			if _, err := e.w.WriteString(fmt.Sprintf("# %s\n", comment)); err != nil {
-				return err
-			}
+		for _, comment := range util.WrapString(c.Translator, enc.wrapWidth) {
+			buff.WriteString("# ")
+			buff.WriteString(comment)
+			buff.WriteString("\n")
 		}
 	}
 
 	if c.Extracted != "" {
-		for _, comment := range util.WrapString(c.Extracted, e.wrapWidth) {
-			if _, err := e.w.WriteString(fmt.Sprintf("#. %s\n", comment)); err != nil {
-				return err
-			}
+		for _, comment := range util.WrapString(c.Extracted, enc.wrapWidth) {
+			buff.WriteString("#. ")
+			buff.WriteString(comment)
+			buff.WriteString("\n")
 		}
 	}
 
-	if len(c.References) > 0 && e.writeReferences {
-		var buff bytes.Buffer
+	if len(c.References) > 0 && enc.writeReferences {
+		builder := strings.Builder{}
 		for i, ref := range c.References {
-			prefix := ""
 			if i > 0 {
-				prefix = " "
+				builder.WriteString(" ")
 			}
+
+			builder.WriteString(ref.Path)
+
 			if ref.Line > 0 {
-				buff.WriteString(fmt.Sprintf("%s%s:%d", prefix, ref.Path, ref.Line))
-			} else {
-				buff.WriteString(fmt.Sprintf("%s%s", prefix, ref.Path))
+				builder.WriteRune(':')
+				builder.WriteString(strconv.Itoa(ref.Line))
 			}
 		}
 
-		for _, comment := range util.WrapString(buff.String(), e.wrapWidth) {
-			if _, err := e.w.WriteString(fmt.Sprintf("#: %s\n", comment)); err != nil {
-				return err
-			}
+		for _, comment := range util.WrapString(builder.String(), enc.wrapWidth) {
+			buff.WriteString("#: ")
+			buff.WriteString(comment)
+			buff.WriteString("\n")
 		}
 	}
 
 	if len(c.Flags) > 0 {
-		if _, err := e.w.WriteString(fmt.Sprintf("#, %s\n", strings.Join(c.Flags, ", "))); err != nil {
-			return err
-		}
+		buff.WriteString("#, ")
+		buff.WriteString(strings.Join(c.Flags, ", "))
+		buff.WriteString("\n")
 	}
-
-	return nil
 }
 
-func (e *Encoder) encodeMessage(m *Message) error {
-	if err := e.encodeComment(m.Comment); err != nil {
-		return err
-	}
+func (enc *Encoder) encodeMessage(buff *bytes.Buffer, m *Message) {
+	enc.encodeComment(buff, m.Comment)
 
 	if m.Context != "" {
-		ctx := fmt.Sprintf("msgctxt %s\n", EncodePoString(m.Context, e.wrapWidth))
-		if _, err := e.w.WriteString(ctx); err != nil {
-			return err
-		}
+		buff.WriteString("msgctxt ")
+		buff.WriteString(EncodePoString(m.Context, enc.wrapWidth))
+		buff.WriteString("\n")
 	}
 
-	msgID := fmt.Sprintf("msgid %s\n", EncodePoString(m.ID, e.wrapWidth))
-	if _, err := e.w.WriteString(msgID); err != nil {
-		return err
-	}
+	buff.WriteString("msgid ")
+	buff.WriteString(EncodePoString(m.ID, enc.wrapWidth))
+	buff.WriteString("\n")
 
 	hasPlural := m.IDPlural != "" || len(m.Str) > 1
 	if hasPlural {
-		pluralID := fmt.Sprintf("msgid_plural %s\n", EncodePoString(m.IDPlural, e.wrapWidth))
-		if _, err := e.w.WriteString(pluralID); err != nil {
-			return err
-		}
+		buff.WriteString("msgid_plural ")
+		buff.WriteString(EncodePoString(m.IDPlural, enc.wrapWidth))
+		buff.WriteString("\n")
 	}
 
-	if err := e.encodeTranslations(hasPlural, m.Str); err != nil {
-		return err
-	}
-
-	return nil
+	enc.encodeTranslations(buff, hasPlural, m.Str)
 }
 
-func (e *Encoder) encodeTranslations(plural bool, orig map[int]string) error {
+func (enc *Encoder) encodeTranslations(buff *bytes.Buffer, plural bool, orig map[int]string) {
 	m := make(map[int]string, len(orig))
 	for k, v := range orig {
-		m[k] = EncodePoString(v, e.wrapWidth)
+		m[k] = EncodePoString(v, enc.wrapWidth)
 	}
 
 	// We need at least one entry
@@ -263,15 +281,43 @@ func (e *Encoder) encodeTranslations(plural bool, orig map[int]string) error {
 		sort.Ints(keys)
 
 		for _, k := range keys {
-			if _, err := e.w.WriteString(fmt.Sprintf("msgstr[%d] %s\n", k, m[k])); err != nil {
-				return err
-			}
+			buff.WriteString(fmt.Sprintf("msgstr[%d] %s\n", k, m[k]))
 		}
 	} else {
-		if _, err := e.w.WriteString(fmt.Sprintf("msgstr %s\n", m[0])); err != nil {
-			return err
+		buff.WriteString("msgstr ")
+		buff.WriteString(m[0])
+		buff.WriteString("\n")
+	}
+}
+
+func DefaultSortFunction(a *Message, b *Message) bool {
+	if a.Comment != nil && b.Comment != nil {
+		a.Comment.sort()
+		b.Comment.sort()
+
+		for i := 0; i < len(a.Comment.References); i++ {
+			if i >= len(b.Comment.References) {
+				break
+			}
+			if c := strings.Compare(a.Comment.References[i].Path, b.Comment.References[i].Path); c != 0 {
+				return c == 1
+			}
+			if c, k := a.Comment.References[i].Line, b.Comment.References[i].Line; c != k {
+				return c > k
+			}
+			if c, k := a.Comment.References[i].Column, b.Comment.References[i].Column; c != k {
+				return c > k
+			}
 		}
 	}
 
-	return nil
+	if a.Context != b.Context {
+		return a.Context > b.Context
+	}
+
+	if a.ID != b.ID {
+		return a.ID > b.ID
+	}
+
+	return false
 }

--- a/catalog/po/encoder_test.go
+++ b/catalog/po/encoder_test.go
@@ -2,11 +2,91 @@ package po
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func ExampleMarshal() {
+	f := NewFile()
+	f.Header = PlaceholderHeader("Spreak", "Florian Vogt", "info@example.org")
+	msg := NewMessage()
+	msg.ID = "Hello"
+	msg.Str[0] = "Hallo"
+	f.AddMessage(msg)
+
+	doc, err := Marshal(f)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(doc))
+}
+
+func ExampleNewEncoder() {
+	f := NewFile()
+	msg := NewMessage()
+	msg.ID = "Hello"
+	msg.Str[0] = "Hallo"
+	f.AddMessage(msg)
+
+	buff := &bytes.Buffer{}
+	enc := NewEncoder(buff)
+	enc.SetWriteEmptyHeader(false)
+	err := enc.Encode(f)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(buff.String())
+	// Output:
+	// msgid "Hello"
+	// msgstr "Hallo"
+
+}
+
+func ExampleEncoder_Encode() {
+	f := NewFile()
+	msg := NewMessage()
+	msg.ID = "Car"
+	msg.IDPlural = "Cars"
+	msg.Str[0] = "Auto"
+	msg.Str[1] = "Autos"
+	f.AddMessage(msg)
+
+	buff := &bytes.Buffer{}
+	enc := NewEncoder(buff)
+	enc.SetWriteEmptyHeader(false)
+	err := enc.Encode(f)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(buff.String())
+	// Output:
+	// msgid "Car"
+	// msgid_plural "Cars"
+	// msgstr[0] "Auto"
+	// msgstr[1] "Autos"
+}
+
+func TestMarshal(t *testing.T) {
+	f := NewFile()
+	msg := NewMessage()
+	msg.ID = "Hello"
+	msg.Str[0] = "Hallo"
+	f.AddMessage(msg)
+
+	doc, err := Marshal(f)
+	if err != nil {
+		panic(err)
+	}
+	want := `
+msgid "Hello"
+msgstr "Hallo"`
+	assert.Contains(t, string(doc), want)
+}
 
 func TestEncoderEmptyFile(t *testing.T) {
 	var buff bytes.Buffer
@@ -90,7 +170,6 @@ msgid "test"
 msgid_plural "test_plural"
 msgstr[0] ""
 msgstr[1] ""
-
 `
 		err := enc.Encode(file)
 		require.NoError(t, err)
@@ -115,7 +194,6 @@ msgid_plural "test_plural"
 msgstr[0] "a"
 msgstr[1] "b"
 msgstr[2] "c"
-
 `
 		buff.Reset()
 
@@ -147,7 +225,6 @@ msgid_plural "test_plural"
 msgstr[0] "a"
 msgstr[1] "b"
 msgstr[2] "c"
-
 `
 
 		buff.Reset()
@@ -172,7 +249,6 @@ msgstr[2] "c"
 msgstr ""
 "ئاۋىستىرالىيە ئىنگلزچىسى\n"
 " "
-
 `
 		assert.Equal(t, want, buff.String())
 	})
@@ -192,7 +268,6 @@ msgstr ""
 		want := `#, fuzzy, go-format
 msgid "Hello"
 msgstr ""
-
 `
 		assert.Equal(t, want, buff.String())
 	})
@@ -225,7 +300,6 @@ msgid "test"
 msgid_plural "test_plural"
 msgstr[0] ""
 msgstr[1] ""
-
 `
 		assert.Equal(t, want, buff.String())
 	})
@@ -252,7 +326,6 @@ msgstr[1] ""
 msgid_plural "test_plural"
 msgstr[0] ""
 msgstr[1] ""
-
 `
 		assert.Equal(t, want, buff.String())
 	})

--- a/catalog/po/file_test.go
+++ b/catalog/po/file_test.go
@@ -104,3 +104,13 @@ msgstr ""
 
 	assert.Equal(t, "val", f.Header.Get("X-UNKNOWN"))
 }
+
+func TestPlaceholderHeader(t *testing.T) {
+	packageName := "Spreak"
+	copyrightHolder := "Florian Vogt"
+	bugsAddress := "bugs@address"
+	h := PlaceholderHeader(packageName, copyrightHolder, bugsAddress)
+	assert.Equal(t, bugsAddress, h.ReportMsgidBugsTo)
+	assert.Equal(t, packageName, h.ProjectIDVersion)
+	assert.Contains(t, h.Comment.Translator, copyrightHolder)
+}

--- a/catalog/po/message.go
+++ b/catalog/po/message.go
@@ -9,8 +9,6 @@ type Message struct {
 	Str      map[int]string
 }
 
-type Messages map[string]map[string]*Message
-
 func NewMessage() *Message {
 	return &Message{
 		Comment: &Comment{
@@ -32,6 +30,8 @@ func (m *Message) AddReference(ref *Reference) {
 	m.Comment.AddReference(ref)
 }
 
+// Deprecated: Will be removed in a future release.
+// Use the DefaultSortFunction.
 func (m *Message) Less(q *Message) bool {
 	if m.Comment != nil && q.Comment != nil {
 		return m.Comment.Less(q.Comment)
@@ -56,17 +56,5 @@ func (m *Message) Merge(other *Message) {
 
 	if m.IDPlural == "" && other.IDPlural != "" {
 		m.IDPlural = other.IDPlural
-	}
-}
-
-func (m Messages) Add(msg *Message) {
-	if _, ok := m[msg.Context]; !ok {
-		m[msg.Context] = make(map[string]*Message)
-	}
-
-	if _, ok := m[msg.Context][msg.ID]; ok {
-		m[msg.Context][msg.ID].Merge(msg)
-	} else {
-		m[msg.Context][msg.ID] = msg
 	}
 }

--- a/catalog/po/parser.go
+++ b/catalog/po/parser.go
@@ -260,7 +260,7 @@ func (p *parser) parseHeader(msg *Message) (*Header, error) {
 
 		key := strings.TrimSpace(line[:colonIdx])
 		val := strings.TrimSpace(line[colonIdx+1:])
-		header.SetField(key, val)
+		header.Set(key, val)
 	}
 	header.Comment = msg.Comment
 

--- a/catalog/po/parser_test.go
+++ b/catalog/po/parser_test.go
@@ -1,12 +1,47 @@
 package po
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func ExampleParseString() {
+	doc := `
+msgid "Hello"
+msgstr "Hallo"
+`
+	f, err := ParseString(doc)
+	if err != nil {
+		panic(err)
+	}
+	msg := f.GetMessage("", "Hello")
+	fmt.Println(msg.ID)
+	fmt.Println(msg.Str[0])
+	// Output:
+	// Hello
+	// Hallo
+}
+
+func ExampleParse() {
+	doc := `
+msgid "Hello"
+msgstr "Hallo"
+`
+	f, err := Parse([]byte(doc))
+	if err != nil {
+		panic(err)
+	}
+	msg := f.GetMessage("", "Hello")
+	fmt.Println(msg.ID)
+	fmt.Println(msg.Str[0])
+	// Output:
+	// Hello
+	// Hallo
+}
 
 func TestParse_Simple(t *testing.T) {
 	t.Run("test parse empty content", func(t *testing.T) {

--- a/catalog/po/util_test.go
+++ b/catalog/po/util_test.go
@@ -1,11 +1,34 @@
 package po
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func ExampleEncodePoString() {
+	s := `Hello
+World`
+	fmt.Println(EncodePoString(s, -1))
+	// Output:
+	// ""
+	// "Hello\n"
+	// "World"
+}
+
+func ExampleDecodePoString() {
+	s := `
+""
+"Hello\n"
+"World"
+`
+	fmt.Println(DecodePoString(s))
+	// Output:
+	// Hello
+	// World
+}
 
 func TestDecode_Newline(t *testing.T) {
 	raw := `"test\n"`

--- a/internal/mo/parser.go
+++ b/internal/mo/parser.go
@@ -240,7 +240,7 @@ func (p *parser) parseMessageHeader(msg *po.Message) (header *po.Header) {
 		}
 		key := strings.TrimSpace(line[:idx])
 		val := strings.TrimSpace(line[idx+1:])
-		header.SetField(key, val)
+		header.Set(key, val)
 	}
 
 	return


### PR DESCRIPTION
#### Summary

* The content of the Po file is now only written to the Writer once it has been completely generated. 
* There is only one empty line at the end of the Po file. 
* The content of Po files is now also sorted by context. This ensures that the export can be repeated as a result. 